### PR TITLE
Reduce arduino library dependency

### DIFF
--- a/YDLidar.cpp
+++ b/YDLidar.cpp
@@ -10,6 +10,10 @@
 
 #ifdef AI_CUSTOMIZED_LIB
 #include "ComStr.h"
+#include "TickTime.hpp"
+#include <cmath>
+#include "Debug.hpp"
+#define millis() TickTime::getTimeMs()
 #endif // #ifdef AI_CUSTOMIZED_LIB
 
 YDLidar::YDLidar()

--- a/YDLidar.h
+++ b/YDLidar.h
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "Arduino.h"
+#include "HardwareSerial.h"
 #include "inc/v8stdint.h"
 
 


### PR DESCRIPTION
Re: https://github.com/bObsweep/platform/pull/1323#discussion_r324258323

Changes:
- Remove reference to Arduino.h and put in necessary header/macro definition