### PR TITLE
Use arduino_serial_port/ArduinoSerialPort directly

### DIFF
--- a/YDLidar.h
+++ b/YDLidar.h
@@ -8,7 +8,11 @@
 
 #pragma once
 
+#ifdef AI_CUSTOMIZED_LIB
+#include "drivers/arduino_serial_port.h"
+#else
 #include "HardwareSerial.h"
+#endif // #ifdef AI_CUSTOMIZED_LIB
 #include "inc/v8stdint.h"
 
 


### PR DESCRIPTION
Re: https://github.com/bObsweep/platform/pull/1323#discussion_r329640230. Also see https://github.com/bObsweep/platform/pull/1374/files#r330834337.